### PR TITLE
Adding function to dynamically resize output

### DIFF
--- a/torchviz/dot.py
+++ b/torchviz/dot.py
@@ -56,6 +56,9 @@ def make_dot(var, params=None):
                     dot.edge(str(id(t)), str(id(var)))
                     add_nodes(t)
     add_nodes(var.grad_fn)
+
+    resize_graph(dot)
+
     return dot
 
 
@@ -125,4 +128,20 @@ def make_dot_from_trace(trace):
         if node.inputs:
             for inp in node.inputs:
                 dot.edge(inp, node.name)
+
+    resize_graph(dot)
+
     return dot
+
+
+def resize_graph(dot, size_per_element=0.15, min_size=12):
+    """Resize the graph according to how much content it contains.
+
+    Modify the graph in place.
+    """
+    # Get the approximate number of nodes and edges
+    num_rows = len(dot.body)
+    content_size = num_rows * size_per_element
+    size = max(min_size, content_size)
+    size_str = str(size) + "," + str(size)
+    dot.graph_attr.update(size=size_str)


### PR DESCRIPTION
With large models, the graphviz output is fixed at 12 inches and the font can become too small to read. This change would dynamically adjust the size of the graph so that it stays legible even as the model sizes get larger.

Before:

![image](https://user-images.githubusercontent.com/958455/39322936-23401320-4940-11e8-9a3c-4cac96fbea26.png)

After:

![image](https://user-images.githubusercontent.com/958455/39322970-3902f3b2-4940-11e8-95e6-488282c94986.png)
