### PR TITLE
Optionally show saved variables and other grad_fn attrs

### DIFF
--- a/torchviz/dot.py
+++ b/torchviz/dot.py
@@ -6,68 +6,134 @@ from torch.autograd import Variable
 
 Node = namedtuple('Node', ('name', 'inputs', 'attr', 'op'))
 
+# Saved attrs for grad_fn (incl. saved variables) begin with `._saved_*`
+SAVED_PREFIX = "_saved_"
 
-def make_dot(var, params=None):
+
+def get_fn_name(fn, show_attrs):
+    name = str(type(fn).__name__)
+    if not show_attrs:
+        return name
+    attrs = dict()
+    for attr in dir(fn):
+        if not attr.startswith(SAVED_PREFIX):
+            continue
+        val = getattr(fn, attr)
+        if torch.is_tensor(val):
+            attrs[attr] = "[saved variable]"
+        elif isinstance(val, tuple) and any(torch.is_tensor(t) for t in val):
+            attrs[attr] = "[saved variables]"
+        else:
+            attrs[attr] = str(getattr(fn, attr))
+    if not attrs:
+        return name
+    col1width = max(len(str(k[len(SAVED_PREFIX):])) for k in attrs.keys())
+    col2width = max(len(str(v)) for v in attrs.values())
+    sep = "-" * max(col1width + col2width + 2, len(name))
+    attrstr = '%-' + str(col1width) + 's: %' + str(col2width)+ 's'
+    params = '\n'.join(attrstr % (k[len(SAVED_PREFIX):], str(v)) for (k, v) in attrs.items())
+    return name + '\n' + sep + '\n' + params
+
+
+def make_dot(var, params=None, show_attrs=False, show_saved=False):
     """ Produces Graphviz representation of PyTorch autograd graph.
 
     Blue nodes are the Variables that require grad, orange are Tensors
-    saved for backward in torch.autograd.Function
-
+    saved for backward in torch.autograd.Function. If output is a view,
+    there is a dotted edge between it and its base.
     Args:
         var: output Variable
         params: dict of (name, Variable) to add names to node that
             require grad (TODO: make optional)
+        show_attrs: whether to display the non-tensor attrs of the backward nodes
+        show_saved: whether to display saved variable nodes
     """
     if params is not None:
         assert all(isinstance(p, Variable) for p in params.values())
         param_map = {id(v): k for k, v in params.items()}
+    else:
+        param_map = {}
 
     node_attr = dict(style='filled',
                      shape='box',
                      align='left',
-                     fontsize='12',
+                     fontsize='10',
                      ranksep='0.1',
-                     height='0.2')
+                     height='0.2',
+                     fontname='monospace')
     dot = Digraph(node_attr=node_attr, graph_attr=dict(size="12,12"))
     seen = set()
 
     def size_to_str(size):
         return '(' + (', ').join(['%d' % v for v in size]) + ')'
 
-    output_nodes = (var.grad_fn,) if not isinstance(var, tuple) else tuple(v.grad_fn for v in var)
+    def get_var_name(var, name=None):
+        name = param_map[id(var)] if id(var) in param_map else ''
+        return '%s\n %s' % (name, size_to_str(var.size()))
 
-    def add_nodes(var):
-        if var not in seen:
-            if torch.is_tensor(var):
-                # note: this used to show .saved_tensors in pytorch0.2, but stopped
-                # working as it was moved to ATen and Variable-Tensor merged
-                dot.node(str(id(var)), size_to_str(var.size()), fillcolor='orange')
-            elif hasattr(var, 'variable'):
-                u = var.variable
-                name = param_map[id(u)] if params is not None else ''
-                node_name = '%s\n %s' % (name, size_to_str(u.size()))
-                dot.node(str(id(var)), node_name, fillcolor='lightblue')
-            elif var in output_nodes:
-                dot.node(str(id(var)), str(type(var).__name__), fillcolor='darkolivegreen1')
-            else:
-                dot.node(str(id(var)), str(type(var).__name__))
-            seen.add(var)
-            if hasattr(var, 'next_functions'):
-                for u in var.next_functions:
-                    if u[0] is not None:
-                        dot.edge(str(id(u[0])), str(id(var)))
-                        add_nodes(u[0])
-            if hasattr(var, 'saved_tensors'):
-                for t in var.saved_tensors:
-                    dot.edge(str(id(t)), str(id(var)))
-                    add_nodes(t)
+    def add_nodes(fn):
+        if fn in seen:
+            return
+        seen.add(fn)
+
+        if show_saved:
+            for attr in dir(fn):
+                if not attr.startswith(SAVED_PREFIX):
+                    continue
+                val = getattr(fn, attr)
+                if torch.is_tensor(val):
+                    dot.edge(str(id(fn)), str(id(val)))
+                    dot.node(str(id(val)), attr[len(SAVED_PREFIX):], fillcolor='orange')
+                if isinstance(val, tuple):
+                    for i, t in enumerate(val):
+                        if torch.is_tensor(t):
+                            name = attr[len(SAVED_PREFIX):] + '[%s]' % str(i)
+                            dot.edge(str(id(fn)), str(id(t)))
+                            dot.node(str(id(t)), name, fillcolor='orange')
+
+        if hasattr(fn, 'variable'):
+            # if grad_accumulator, add the node for `.variable`
+            var = fn.variable
+            dot.node(str(id(var)), get_var_name(var), fillcolor='lightblue')
+            dot.edge(str(id(var)), str(id(fn)))
+
+        # add the node for this grad_fn
+        dot.node(str(id(fn)), get_fn_name(fn, show_attrs))
+
+        # recurse
+        if hasattr(fn, 'next_functions'):
+            for u in fn.next_functions:
+                if u[0] is not None:
+                    dot.edge(str(id(u[0])), str(id(fn)))
+                    add_nodes(u[0])
+
+        # note: this used to show .saved_tensors in pytorch0.2, but stopped
+        # working as it was moved to ATen and Variable-Tensor merged
+        if hasattr(fn, 'saved_tensors'):
+            for t in fn.saved_tensors:
+                dot.edge(str(id(t)), str(id(fn)))
+                dot.node(str(id(t)), get_var_name(t), fillcolor='orange')
+
+
+    def add_base_tensor(var, color='green'):
+        if var in seen:
+            return
+        dot.node(str(id(var)), get_var_name(var), fillcolor=color)
+        if (var.grad_fn):
+            add_nodes(var.grad_fn)
+            dot.edge(str(id(var.grad_fn)), str(id(var)))
+        if var._is_view():
+            add_base_tensor(var._base, color='lightgreen')
+            dot.edge(str(id(var._base)), str(id(var)), style="dotted")
+        seen.add(var)
+
 
     # handle multiple outputs
     if isinstance(var, tuple):
         for v in var:
-            add_nodes(v.grad_fn)
+            add_base_tensor(v)
     else:
-        add_nodes(var.grad_fn)
+        add_base_tensor(var)
 
     resize_graph(dot)
 

--- a/torchviz/dot.py
+++ b/torchviz/dot.py
@@ -82,10 +82,14 @@ def make_dot(var, params=None, show_attrs=False, show_saved=False, max_attr_char
         seen.add(fn)
 
         if show_saved:
+            # objects with non-overlapping lifetimes may share the same id, lets keep
+            # all objects alive at the same time so their ids cant clash
+            vals = []
             for attr in dir(fn):
                 if not attr.startswith(SAVED_PREFIX):
                     continue
                 val = getattr(fn, attr)
+                vals.append(val)
                 attr = attr[len(SAVED_PREFIX):]
                 if torch.is_tensor(val):
                     dot.edge(str(id(fn)), str(id(val)))


### PR DESCRIPTION
Pytorch master now has python bindings for saved variables and other non-tensor attrs. This PR adds support to display what pytorch now provides. See https://github.com/pytorch/pytorch/pull/52451

We also:
 - Make accumulate grad node explicit
 - Add capability to see view relationship between output tensor and its base from (https://github.com/alband/pytorchviz/tree/more_elements) by @albanD
 - As seen below, we have to make the font monospace so the attrs display neatly
 
Examples:
```
a = torch.tensor(1., requires_grad=True)
b = a.view(-1)
make_dot(b, show_attrs=True)
```
![image](https://user-images.githubusercontent.com/13428986/110028872-ce07f780-7d01-11eb-9deb-5d14be584e22.png)

```
a = torch.ones(1, requires_grad=True)
b = torch.ones(1, requires_grad=True)
out = torch.stack([a, b], dim=0)
make_dot(out, show_attrs=True, show_saved=True)
```
![image](https://user-images.githubusercontent.com/13428986/110028827-c0527200-7d01-11eb-96ef-d942f0b30f33.png)

```
model = nn.Sequential()
model.add_module('W0', nn.Linear(8, 16))
model.add_module('tanh', nn.Tanh())
model.add_module('W1', nn.Linear(16, 1))
y = model(torch.randn(1, 8))
make_dot(y.mean(), params=dict(model.named_parameters()), show_attrs=True, show_saved=True)
```
![image](https://user-images.githubusercontent.com/13428986/110028755-a749c100-7d01-11eb-8ab4-6febaca5d8a9.png)
Verify that custom autograd functions still have saved tensor nodes even if `show_saved` is `False`
```
class Test(torch.autograd.Function):
    @staticmethod
    def forward(ctx, x):
        ctx.save_for_backward(x)
        return x
    @staticmethod
    def backward(ctx, gO):
        x, = ctx.saved_tensors
        return gO
a = torch.ones(2, 2, requires_grad=True)
out = Test.apply(a)
make_dot(out)
```
![image](https://user-images.githubusercontent.com/13428986/110031274-b2522080-7d04-11eb-8486-6af91be4d906.png)



