### PR TITLE
Allow HTML formatting of labels

### DIFF
--- a/torchviz/dot.py
+++ b/torchviz/dot.py
@@ -91,7 +91,7 @@ def make_dot(var, params=None, show_attrs=False, show_saved=False, max_attr_char
     def get_var_name(var, name=None):
         if not name:
             name = param_map[id(var)] if id(var) in param_map else ''
-        return '%s\n %s' % (name, size_to_str(var.size()))
+        return r'<%s <br/><br/> %s>' % (name, size_to_str(var.size()))
 
     def add_nodes(fn):
         assert not torch.is_tensor(fn)


### PR DESCRIPTION
This is a very small change that would allow the full use of the graphviz HTML formatting for each node label.
I'm not quite sure if this breaks something else, or if these results could be obtained in another way, but this is how it would work. Let's say I want to use subscripts for weight matrices `w_1` and `w_2`:

``` python
make_dot(loss,params={'w<sub>1</sub>':w1,'w<sub>2</sub>':w2})
```

![graphviz example](https://user-images.githubusercontent.com/5016602/111570339-e0524e80-8761-11eb-9150-cc541ff61c11.png)

I had to add double space (i.e. `<br/><br/>`) otherwise the lines would overlap.