### PR TITLE
Add open in colab badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ PyTorchViz
 
 A small package to create visualizations of PyTorch execution graphs and traces.
 
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/szagoruyko/pytorchviz/blob/master/examples.ipynb)
+
 ## Installation
 
 Install graphviz, e.g.:

--- a/examples.ipynb
+++ b/examples.ipynb
@@ -16,6 +16,7 @@
    "source": [
     "import torch\n",
     "from torch import nn\n",
+    "%pip install -U git+https://github.com/szagoruyko/pytorchviz.git@master\n",
     "from torchviz import make_dot, make_dot_from_trace"
    ]
   },


### PR DESCRIPTION
Adds “open in colab badge” and adds a line to install the package in the first cell of examples.ipynb.

@albanD wdyt?