### PR TITLE
Use str(v) instead of '%d' % v to stringify sizes

### DIFF
--- a/torchviz/dot.py
+++ b/torchviz/dot.py
@@ -86,7 +86,7 @@ def make_dot(var, params=None, show_attrs=False, show_saved=False, max_attr_char
     seen = set()
 
     def size_to_str(size):
-        return '(' + (', ').join(['%d' % v for v in size]) + ')'
+        return '(' + (', ').join([str(v) for v in size]) + ')'
 
     def get_var_name(var, name=None):
         if not name:


### PR DESCRIPTION
Nested tensors can have sizes that cannot be converted to ints (e.g. singleton symints representing the jagged dimension, like [4, j0, 8]). str() is supported on singleton symints.